### PR TITLE
Reveal that code presumes dplyr is attached

### DIFF
--- a/introduction.Rmd
+++ b/introduction.Rmd
@@ -3,7 +3,6 @@
 
 ```{r setup, include = FALSE}
 source("setup.R")
-library("dplyr")
 ```
 
 
@@ -12,6 +11,8 @@ library("dplyr")
 Tidyverse grammars like dplyr have a distinctive look and feel. This is in part because their design follows a set of [principles](https://principles.tidyverse.org/). However, their most important feature is that they let you work with your data as if they were actual objects in your workspace. In a way, the data frame temporarily becomes the workspace. When the contents of the data frame are temporarily promoted as objects in the workspace, we say the data **masks** the workspace:
 
 ```{r, eval = FALSE}
+library(dplyr)
+
 # Masking data
 starwars %>%
   filter(


### PR DESCRIPTION
I've adopted a policy lately that any single page, blog post, etc. should work well with copy/paste. So I think you should reveal `library(dplyr)` here, even thought you don't execute the code. A reader might.