### PR TITLE
Minor change made to ordering of statements in code block in order to correspond with ordering of concepts in preceding sentence

### DIFF
--- a/introduction.Rmd
+++ b/introduction.Rmd
@@ -671,10 +671,10 @@ df <- data.frame(
   var = 2
 )
 
-df$y
-
 var <- "y"
 df[[var]]
+
+df$y
 ```
 
 Technically, `[[` is an evaluating function while `$` is a quoting function.  You can indirectly refer to columns with `[[` because the subsetting index is evaluated, allowing indirect references. The following expressions are completely equivalent:


### PR DESCRIPTION
This caused me some confusion. The sentence leading up to the code block refers to the indexing operators `[[` as "the former" and `$` as "the latter". 

But in the code block, the order in which these operators are demonstrated is reversed (`$` is "the former" and `[[` is "the latter").