### PR TITLE
Update variable names for consistency

### DIFF
--- a/dotdotdot.Rmd
+++ b/dotdotdot.Rmd
@@ -189,7 +189,7 @@ grouped_mean2 <- function(.data, .summary_var, ...) {
 
   .data %>%
     group_by(!!!.group_vars) %>%
-    summarise(mean = mean(!!summary_var))
+    summarise(mean = mean(!!.summary_var))
 }
 ```
 

--- a/dotdotdot.Rmd
+++ b/dotdotdot.Rmd
@@ -138,13 +138,13 @@ When we need to modify the arguments or their names, we can't simply forward the
 While the singular `enquo()` returns a single quoted argument, the plural variant `enquos()` returns a list of quoted arguments. Let's use it to quote the dots:
 
 ```{r}
-grouped_mean2 <- function(data, summary_var, ...) {
-  summary_var <- enquo(summary_var)
-  group_vars <- enquos(...)
+grouped_mean2 <- function(.data, .summary_var, ...) {
+  .summary_var <- enquo(.summary_var)
+  .group_vars <- enquos(...)
 
   data %>%
-    group_by(!!group_vars) %>%
-    summarise(mean = mean(!!summary_var))
+    group_by(!!.group_vars) %>%
+    summarise(mean = mean(!!.summary_var))
 }
 ```
 
@@ -184,11 +184,11 @@ When we use the unquote operator `!!`, `group_by()` gets a list of expressions. 
 
 ```{r}
 grouped_mean2 <- function(.data, .summary_var, ...) {
-  summary_var <- enquo(.summary_var)
-  group_vars <- enquos(...)
+  .summary_var <- enquo(.summary_var)
+  .group_vars <- enquos(...)
 
   .data %>%
-    group_by(!!!group_vars) %>%
+    group_by(!!!.group_vars) %>%
     summarise(mean = mean(!!summary_var))
 }
 ```


### PR DESCRIPTION
After we say this
> It is good practice to make one final adjustment. Because arguments in ... can have arbitrary names, we don’t want to “use up” valid names. In tidyverse packages we use the convention of prefixing named arguments with a dot so that conflicts are less likely:

lets stick with that convention in the rest of the text
